### PR TITLE
Disable X11 support for TeX Live

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -72,7 +72,8 @@ mkdir -p tmp_build && pushd tmp_build
                --with-mprf-libdir=$PREFIX/lib \
                --without-system-harfbuzz \
                --without-system-graphite2 \
-               --without-system-poppler
+               --without-system-poppler \
+               --without-x
   make
   eval ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib" LC_ALL=C make check
   make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a8b32ca47f0a403661a09e202f4567a995beb718c18d8f81ca6d76daa1da21ed
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win]
   detect_binary_files_with_prefix: true
 


### PR DESCRIPTION
Fixes https://github.com/conda-forge/texlive-core-feedstock/issues/13

Seems to be causing failures on OS X. Once we sort out how we want to handle X11 in conda-forge, we can probably make use of our own X11 libraries to provide support for this.